### PR TITLE
Zsh completion for coral cd

### DIFF
--- a/completions/coral.zsh
+++ b/completions/coral.zsh
@@ -12,7 +12,12 @@ _coral() {
   if [ "${#words}" -eq 2 ]; then
     completions="$(coral commands)"
   else
-    completions="$(coral completions "${word}")"
+    if [[ $word -eq "cd" ]]
+    then
+      completions="$(coral path --complete)"
+    else
+      completions="$(coral completions "${word}")"
+    fi
   fi
 
   reply=("${(ps:\n:)completions}")


### PR DESCRIPTION
This change adds completion for `coral cd` which doesn't work out of the box due to the `sh-cd` bridge.

```
❯ coral cd base<tab>
base16-iterm2             base16-osx-color-palette
```
